### PR TITLE
feat: enforce paper a pass logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [AGENT.MD](./AGENT.md) for full product and behavior specifications.
 
 ## Passing Criteria
 
-Paper A combines Module 1 (30 questions) and Module 2 (5 questions). A minimum of 30 correct answers is required to pass the paper. For example, scoring 24 in Module 1 makes passing impossible, while scoring 25 means Module 2 must be answered perfectly.
+Paper A combines Module 1 (30 questions) and Module 2 (5 questions). A minimum of 30 correct answers is required to pass the paper. For example, scoring 24 in Module 1 makes passing impossible, while scoring 25 means Module 2 must be answered perfectly. Module 1 results display "Pending" if your score still allows a pass after Module 2.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # PDVL Mock Assessments
 
-A lightweight Next.js app for practicing PDVL modules. 
+A lightweight Next.js app for practicing PDVL modules.
 
 See [AGENT.MD](./AGENT.md) for full product and behavior specifications.
+
+## Passing Criteria
+
+Paper A combines Module 1 (30 questions) and Module 2 (5 questions). A minimum of 30 correct answers is required to pass the paper. For example, scoring 24 in Module 1 makes passing impossible, while scoring 25 means Module 2 must be answered perfectly.
 
 ## Setup
 

--- a/src/app/assess/[paper]/[module]/[seed]/result/ResultsClient.tsx
+++ b/src/app/assess/[paper]/[module]/[seed]/result/ResultsClient.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { MODULE_CONFIG } from '@/lib/config';
 import type { Question } from '@/lib/questions';
-import { canPassPaperA } from '@/lib/score';
+import { canPassPaperA, paperAStatusAfterModule1 } from '@/lib/score';
 import { generateSeed } from '@/lib/seed';
 
 interface Props {
@@ -74,21 +74,26 @@ export default function ResultsClient({paper, moduleKey, seed, questions}: Props
     };
   }
 
-  const userPassed = paper === 'a' && combined
-    ? canPassPaperA(combined.m1Score, score)
-    : combined
-      ? combined.score >= passMark
-      : score >= passMark;
+  let userPassed: boolean | null;
+  if (paper === 'a' && moduleKey === 'm1') {
+    userPassed = paperAStatusAfterModule1(score);
+  } else if (paper === 'a' && combined) {
+    userPassed = canPassPaperA(combined.m1Score, score);
+  } else if (combined) {
+    userPassed = combined.score >= passMark;
+  } else {
+    userPassed = score >= passMark;
+  }
 
   return (
     <div className="space-y-8">
       <header className="flex flex-row justify-between flex-wrap items-center gap-4 *:!m-0">
         <p>
           <span className={clsx({
-            'text-green-500': userPassed,
-            'text-red-500': !userPassed,
+            'text-green-500': userPassed === true,
+            'text-red-500': userPassed === false,
           })}>
-            {userPassed ? 'Pass' : 'Fail'}
+            {userPassed === null ? 'Pending' : userPassed ? 'Pass' : 'Fail'}
           </span>
         </p>
         <p>

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -1,0 +1,10 @@
+import { canPassPaperA } from '../score';
+
+test('fails if module 1 score is 24 even with perfect module 2', () => {
+  expect(canPassPaperA(24, 5)).toBe(false);
+});
+
+test('requires a perfect module 2 when module 1 score is 25', () => {
+  expect(canPassPaperA(25, 5)).toBe(true);
+  expect(canPassPaperA(25, 4)).toBe(false);
+});

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -1,4 +1,4 @@
-import { canPassPaperA } from '../score';
+import { canPassPaperA, paperAStatusAfterModule1 } from '../score';
 
 test('fails if module 1 score is 24 even with perfect module 2', () => {
   expect(canPassPaperA(24, 5)).toBe(false);
@@ -7,4 +7,16 @@ test('fails if module 1 score is 24 even with perfect module 2', () => {
 test('requires a perfect module 2 when module 1 score is 25', () => {
   expect(canPassPaperA(25, 5)).toBe(true);
   expect(canPassPaperA(25, 4)).toBe(false);
+});
+
+test('module 1 result is pending if score allows a pass with module 2', () => {
+  expect(paperAStatusAfterModule1(25)).toBeNull();
+});
+
+test('module 1 result fails when pass is impossible', () => {
+  expect(paperAStatusAfterModule1(24)).toBe(false);
+});
+
+test('module 1 result passes when already above pass mark', () => {
+  expect(paperAStatusAfterModule1(30)).toBe(true);
 });

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -1,0 +1,5 @@
+export const PAPER_A_PASS_MARK = 30;
+
+export function canPassPaperA(module1Correct: number, module2Correct: number): boolean {
+  return module1Correct + module2Correct >= PAPER_A_PASS_MARK;
+}

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -1,5 +1,13 @@
+import { MODULE_CONFIG } from './config';
+
 export const PAPER_A_PASS_MARK = 30;
 
 export function canPassPaperA(module1Correct: number, module2Correct: number): boolean {
   return module1Correct + module2Correct >= PAPER_A_PASS_MARK;
+}
+
+export function paperAStatusAfterModule1(module1Correct: number): boolean | null {
+  if (module1Correct + MODULE_CONFIG.a.m2.count < PAPER_A_PASS_MARK) return false;
+  if (module1Correct >= PAPER_A_PASS_MARK) return true;
+  return null;
 }


### PR DESCRIPTION
## Summary
- document Paper A passing requirements in README
- centralize Paper A pass check and use it in results page
- test pass helper for edge cases

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c744a804832087b92d3bf9de62d1